### PR TITLE
extend CAD-BOM to support SolidWorks configurations

### DIFF
--- a/VDS-MFG-Sample/Vault.Custom/Configuration/File/ADSK.QS.CAD BOM.xaml
+++ b/VDS-MFG-Sample/Vault.Custom/Configuration/File/ADSK.QS.CAD BOM.xaml
@@ -70,7 +70,7 @@
                 <ColumnDefinition Width="305"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Label Content="{Binding UIString[ADSK.TS.CAD-BOM03], FallbackValue='Model State'}"/>
+            <Label x:Name="lblBomVariant" Content="{Binding UIString[ADSK.TS.CAD-BOM03], FallbackValue='Model State'}"/>
             <ComboBox x:Name="cmbModelStates" Width="Auto" MinWidth="200" VerticalAlignment="Center" Grid.Column="1" DisplayMemberPath="Key" SelectedValuePath="Value" MaxWidth="300" HorizontalAlignment="Left"/>
             <Button x:Name="btnCadBomClear" IsEnabled="False" Command="{Binding PsCmd[CadBomClearButton_Click]}" Grid.Column="2" Content="  X  " Foreground="Red" FontWeight="Bold" HorizontalAlignment="Right" Margin="20,1,0,1" ToolTip="Clear search text"/>
             <TextBox x:Name="txtCadBomSearch" Grid.Column="3" TextWrapping="Wrap" Text="" IsReadOnly="False" MaxWidth="300"/>

--- a/VDS-MFG-Sample/Vault.Custom/addinVault/ADSK.QS.Default.ps1
+++ b/VDS-MFG-Sample/Vault.Custom/addinVault/ADSK.QS.Default.ps1
@@ -384,6 +384,12 @@ function OnTabContextChanged
 			}
 		}
 
+		# read configuration names for sldasm files
+		if ($file.Name -match "\.sldasm$" ) {
+			$_MsArray = @()
+			$_MsArray += mGetMdlStates($file.id)
+		}
+
 		#read the primary BOM
 		try {
 			$bom = @(GetFileBOM $file.id 0)

--- a/VDS-MFG-Sample/Vault.Custom/addinVault/ADSK.QS.FileBOM.ps1
+++ b/VDS-MFG-Sample/Vault.Custom/addinVault/ADSK.QS.FileBOM.ps1
@@ -15,32 +15,110 @@ class mBom {
 }
 
 function mGetMdlStates($fileID) {
-		
+	
 	$global:mFileBOM = $vault.DocumentService.GetBOMByFileId($fileID)
-	#$dsDiag.Inspect("mFileBOM")
+
+	# get UIStrings for localization
+	$UIStrings = mGetUIStrings
+	
+	# Get the file to determine its CAD provider
+	$mFile = $vault.DocumentService.GetFileById($fileID)
+	
+	# Read the Provider property to determine if it's Inventor or SolidWorks
+	$propDefs = $vault.PropertyService.GetPropertyDefinitionsByEntityClassId('FILE')
+	$providerPropDef = $propDefs | Where-Object {$_.SysName -eq 'Provider'}
+	
+	$mCadProvider = "Unknown"
+	if ($providerPropDef) {
+		$providerProp = $vault.PropertyService.GetProperties('FILE', @($fileID), @($providerPropDef.Id))[0]
+		$providerValue = $providerProp.Val
+		
+		if ($providerValue -like "*Inventor*") {
+			$mCadProvider = "Inventor"
+		}
+		elseif ($providerValue -like "*SolidWorks*") {
+			$mCadProvider = "SolidWorks"
+		}
+	}
+	
 	$MsArray = @()
-	$MsArray += $mFileBom.CompArray | Where-Object { $_.XRefId -eq -1 -and ($_.UniqueId -like "MS:*" -or $_.Name -match "\[.*\]") } # model state BOMs are internal component BOMs
+	
+	# Filter components based on CAD provider
+	if ($mCadProvider -eq "SolidWorks") {
+		# SolidWorks configurations: XRefId = -1 AND UniqueId contains "@"
+		$MsArray += $mFileBom.CompArray | Where-Object { 
+			$_.XRefId -eq -1 -and $_.UniqueId -ne $null -and $_.UniqueId.Contains("@")
+		}
+	}
+	elseif ($mCadProvider -eq "Inventor") {
+		# Inventor model states: XRefId = -1 AND (UniqueId starts with "MS:" OR Name matches [...])
+		$MsArray += $mFileBom.CompArray | Where-Object { 
+			$_.XRefId -eq -1 -and (
+				($_.UniqueId -ne $null -and $_.UniqueId -like "MS:*") -or 
+				($_.Name -ne $null -and $_.Name -match "\[.*\]")
+			)
+		}
+	}
 	
 	if ($MsArray.Count -gt 1) {
 		$mMdlStates = @{}
 		$MsArray | ForEach-Object { 
 			$mName = ""
-			if ($_.Name -match "\[.*\]") {
-				$mName = "[Primary]"
+			
+			if ($mCadProvider -eq "SolidWorks") {
+				# Extract SolidWorks configuration name
+				# Format: "ConfigName@AssemblyName.SLDASM"
+				if ($_.Name -ne $null) {
+					$nameParts = $_.Name.Split("@")
+					if ($nameParts.Length -eq 2 -and $nameParts[1] -eq $mFile.Name) {
+						$mName = $nameParts[0]
+					}
+					else {
+						$mName = $_.Name
+					}
+				}
 			}
-			if ($_.Name -like "* (*)") {
-				#get the model state name
-				$mName = $_.Name.Split(" (")[1]
-				$mName = $mName.Substring(0, $mName.Length - 1)					
-			}	#add the primary state name		
-
-			$mMdlStates.Add($mName, $_.Id)		
+			elseif ($mCadProvider -eq "Inventor") {
+				# Extract Inventor model state name
+				if ($_.Name -match "\[.*\]") {
+					$mName = "[Primary]"
+				}
+				if ($_.Name -like "* (*)") {
+					# Extract name from format: "AssemblyName (ModelStateName)"
+					$startIndex = $_.Name.IndexOf(" (")
+					$endIndex = $_.Name.IndexOf(")")
+					if ($startIndex -ge 0 -and $endIndex -gt $startIndex) {
+						$mName = $_.Name.Substring($startIndex + 2, $endIndex - $startIndex - 2)
+					}
+				}
+			}
+			
+			if (-not [string]::IsNullOrEmpty($mName)) {
+				try {
+					$mMdlStates.Add($mName, $_.Id)
+				}
+				catch {
+					# Handle duplicate names
+					$dsDiag.Trace("Duplicate variant name: $mName")
+				}
+			}
 		}
-		#sort the model states by name
+		
+		# Sort and display model states/configurations
 		$mMdlStates = $mMdlStates.GetEnumerator() | Sort-Object Name		
 		$dsWindow.FindName("cmbModelStates").ItemsSource = $mMdlStates
 		$dsWindow.FindName("cmbModelStates").SelectedIndex = 0
 		$dsWindow.FindName("cmbModelStates").IsEnabled = $true
+		
+		# Update the label based on CAD provider
+		if ($dsWindow.FindName("lblBomVariant")) {
+			if ($mCadProvider -eq "SolidWorks") {
+				$dsWindow.FindName("lblBomVariant").Content = $UIStrings["ADSK.TS.CAD-BOM05"] # "Configuration:"]
+			}
+			else {
+				$dsWindow.FindName("lblBomVariant").Content = $UIStrings["ADSK.TS.CAD-BOM03"] # "Model State:"]
+			}
+		}
 	}
 	else {
 		$dsWindow.FindName("cmbModelStates").IsEnabled = $false

--- a/VDS-MFG-Sample/de-DE/UIStrings.xml
+++ b/VDS-MFG-Sample/de-DE/UIStrings.xml
@@ -239,6 +239,7 @@
   <UIString ID="MSDCE_CAD-BOM02">Achtung - Gewählte Komponente enthält keine CAD-BOM Daten.</UIString>
   <UIString ID="ADSK.TS.CAD-BOM03">Modellzustand</UIString>
   <UIString ID="ADSK.TS.CAD-BOM04">Finde</UIString>
+  <UIString ID="ADSK.TS.CAD-BOM05">Konfiguration</UIString>
   <!--VDS Sample CAD-BOM end-->
 
   <!--VDS Sample Inventor Dialog-->

--- a/VDS-MFG-Sample/en-US/UIStrings.xml
+++ b/VDS-MFG-Sample/en-US/UIStrings.xml
@@ -240,6 +240,7 @@
   <UIString ID="MSDCE_CAD-BOM02">Note - Selected component has no CAD-BOM data available.</UIString>
   <UIString ID="ADSK.TS.CAD-BOM03">Model State</UIString>
   <UIString ID="ADSK.TS.CAD-BOM04">Find</UIString>
+  <UIString ID="ADSK.TS.CAD-BOM05">Configuration</UIString>
   <!--VDS Sample CAD-BOM end-->
 
   <!--VDS Sample Inventor Dialog-->

--- a/VDS-PDMC-Sample/Vault.Custom/Configuration/File/ADSK.QS.CAD BOM.xaml
+++ b/VDS-PDMC-Sample/Vault.Custom/Configuration/File/ADSK.QS.CAD BOM.xaml
@@ -70,7 +70,7 @@
                 <ColumnDefinition Width="305"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <Label Content="{Binding UIString[ADSK.TS.CAD-BOM03], FallbackValue='Model State'}"/>
+            <Label x:Name="lblBomVariant" Content="{Binding UIString[ADSK.TS.CAD-BOM03], FallbackValue='Model State'}"/>
             <ComboBox x:Name="cmbModelStates" Width="Auto" MinWidth="200" VerticalAlignment="Center" Grid.Column="1" DisplayMemberPath="Key" SelectedValuePath="Value" MaxWidth="300" HorizontalAlignment="Left"/>
             <Button x:Name="btnCadBomClear" IsEnabled="False" Command="{Binding PsCmd[CadBomClearButton_Click]}" Grid.Column="2" Content="  X  " Foreground="Red" FontWeight="Bold" HorizontalAlignment="Right" Margin="20,1,0,1" ToolTip="Clear search text"/>
             <TextBox x:Name="txtCadBomSearch" Grid.Column="3" TextWrapping="Wrap" Text="" IsReadOnly="False" MaxWidth="300"/>

--- a/VDS-PDMC-Sample/Vault.Custom/addinVault/ADSK.QS.Default.ps1
+++ b/VDS-PDMC-Sample/Vault.Custom/addinVault/ADSK.QS.Default.ps1
@@ -433,6 +433,12 @@ function OnTabContextChanged {
 			}
 		}
 
+		# read configuration names for sldasm files
+		if ($file.Name -match "\.sldasm$" ) {
+			$_MsArray = @()
+			$_MsArray += mGetMdlStates($file.id)
+		}
+
 		#read the primary BOM
 		try {
 			$bom = @(GetFileBOM $file.id 0)

--- a/VDS-PDMC-Sample/Vault.Custom/addinVault/ADSK.QS.FileBOM.ps1
+++ b/VDS-PDMC-Sample/Vault.Custom/addinVault/ADSK.QS.FileBOM.ps1
@@ -15,32 +15,110 @@ class mBom {
 }
 
 function mGetMdlStates($fileID) {
-		
+	
 	$global:mFileBOM = $vault.DocumentService.GetBOMByFileId($fileID)
-	#$dsDiag.Inspect("mFileBOM")
+
+	# get UIStrings for localization
+	$UIStrings = mGetUIStrings
+
+	# Get the file to determine its CAD provider
+	$mFile = $vault.DocumentService.GetFileById($fileID)
+	
+	# Read the Provider property to determine if it's Inventor or SolidWorks
+	$propDefs = $vault.PropertyService.GetPropertyDefinitionsByEntityClassId('FILE')
+	$providerPropDef = $propDefs | Where-Object {$_.SysName -eq 'Provider'}
+	
+	$mCadProvider = "Unknown"
+	if ($providerPropDef) {
+		$providerProp = $vault.PropertyService.GetProperties('FILE', @($fileID), @($providerPropDef.Id))[0]
+		$providerValue = $providerProp.Val
+		
+		if ($providerValue -like "*Inventor*") {
+			$mCadProvider = "Inventor"
+		}
+		elseif ($providerValue -like "*SolidWorks*") {
+			$mCadProvider = "SolidWorks"
+		}
+	}
+	
 	$MsArray = @()
-	$MsArray += $mFileBom.CompArray | Where-Object { $_.XRefId -eq -1 -and ($_.UniqueId -like "MS:*" -or $_.Name -match "\[.*\]") } # model state BOMs are internal component BOMs
+	
+	# Filter components based on CAD provider
+	if ($mCadProvider -eq "SolidWorks") {
+		# SolidWorks configurations: XRefId = -1 AND UniqueId contains "@"
+		$MsArray += $mFileBom.CompArray | Where-Object { 
+			$_.XRefId -eq -1 -and $_.UniqueId -ne $null -and $_.UniqueId.Contains("@")
+		}
+	}
+	elseif ($mCadProvider -eq "Inventor") {
+		# Inventor model states: XRefId = -1 AND (UniqueId starts with "MS:" OR Name matches [...])
+		$MsArray += $mFileBom.CompArray | Where-Object { 
+			$_.XRefId -eq -1 -and (
+				($_.UniqueId -ne $null -and $_.UniqueId -like "MS:*") -or 
+				($_.Name -ne $null -and $_.Name -match "\[.*\]")
+			)
+		}
+	}
 	
 	if ($MsArray.Count -gt 1) {
 		$mMdlStates = @{}
 		$MsArray | ForEach-Object { 
 			$mName = ""
-			if ($_.Name -match "\[.*\]") {
-				$mName = "[Primary]"
+			
+			if ($mCadProvider -eq "SolidWorks") {
+				# Extract SolidWorks configuration name
+				# Format: "ConfigName@AssemblyName.SLDASM"
+				if ($_.Name -ne $null) {
+					$nameParts = $_.Name.Split("@")
+					if ($nameParts.Length -eq 2 -and $nameParts[1] -eq $mFile.Name) {
+						$mName = $nameParts[0]
+					}
+					else {
+						$mName = $_.Name
+					}
+				}
 			}
-			if ($_.Name -like "* (*)") {
-				#get the model state name
-				$mName = $_.Name.Split(" (")[1]
-				$mName = $mName.Substring(0, $mName.Length - 1)					
-			}	#add the primary state name		
-
-			$mMdlStates.Add($mName, $_.Id)		
+			elseif ($mCadProvider -eq "Inventor") {
+				# Extract Inventor model state name
+				if ($_.Name -match "\[.*\]") {
+					$mName = "[Primary]"
+				}
+				if ($_.Name -like "* (*)") {
+					# Extract name from format: "AssemblyName (ModelStateName)"
+					$startIndex = $_.Name.IndexOf(" (")
+					$endIndex = $_.Name.IndexOf(")")
+					if ($startIndex -ge 0 -and $endIndex -gt $startIndex) {
+						$mName = $_.Name.Substring($startIndex + 2, $endIndex - $startIndex - 2)
+					}
+				}
+			}
+			
+			if (-not [string]::IsNullOrEmpty($mName)) {
+				try {
+					$mMdlStates.Add($mName, $_.Id)
+				}
+				catch {
+					# Handle duplicate names
+					$dsDiag.Trace("Duplicate variant name: $mName")
+				}
+			}
 		}
-		#sort the model states by name
+		
+		# Sort and display model states/configurations
 		$mMdlStates = $mMdlStates.GetEnumerator() | Sort-Object Name		
 		$dsWindow.FindName("cmbModelStates").ItemsSource = $mMdlStates
 		$dsWindow.FindName("cmbModelStates").SelectedIndex = 0
 		$dsWindow.FindName("cmbModelStates").IsEnabled = $true
+		
+		# Update the label based on CAD provider
+		if ($dsWindow.FindName("lblBomVariant")) {
+			if ($mCadProvider -eq "SolidWorks") {
+				$dsWindow.FindName("lblBomVariant").Content = $UIStrings["ADSK.TS.CAD-BOM05"] # "Configuration:"]
+			}
+			else {
+				$dsWindow.FindName("lblBomVariant").Content = $UIStrings["ADSK.TS.CAD-BOM03"] # "Model State:"]
+			}
+		}
 	}
 	else {
 		$dsWindow.FindName("cmbModelStates").IsEnabled = $false

--- a/VDS-PDMC-Sample/de-DE/UIStrings.xml
+++ b/VDS-PDMC-Sample/de-DE/UIStrings.xml
@@ -262,6 +262,7 @@
   <UIString ID="MSDCE_CAD-BOM02">Achtung - Gewählte Komponente enthält keine CAD-BOM Daten.</UIString>
   <UIString ID="ADSK.TS.CAD-BOM03">Modellzustand</UIString>
   <UIString ID="ADSK.TS.CAD-BOM04">Finde</UIString>
+  <UIString ID="ADSK.TS.CAD-BOM05">Konfiguration</UIString>
   <!--VDS-PDMC-Sample CAD-BOM end-->
 
   <!--VDS-PDMC-Sample Inventor Dialog-->

--- a/VDS-PDMC-Sample/en-US/UIStrings.xml
+++ b/VDS-PDMC-Sample/en-US/UIStrings.xml
@@ -263,6 +263,7 @@
   <UIString ID="MSDCE_CAD-BOM02">Note - Selected component has no CAD-BOM data available.</UIString>
   <UIString ID="ADSK.TS.CAD-BOM03">Model State</UIString>
   <UIString ID="ADSK.TS.CAD-BOM04">Find</UIString>
+  <UIString ID="ADSK.TS.CAD-BOM05">Configuration</UIString>
   <!--VDS-PDMC-Sample CAD-BOM end-->
 
   <!--VDS-PDMC-Sample Inventor Dialog-->


### PR DESCRIPTION
the CAD-BOM tab can leverage the BOM object to read the BOM for SWX configurations like for Inventor Model States.
Known limitation is the static configuration of the CAD-BOM columns; SWX BOMs likely use different property names, e.g., the *CONF* <PropertyName> mapping convention.